### PR TITLE
Amended Satansvisan and fixed issues with it.

### DIFF
--- a/sangbok/main.xml
+++ b/sangbok/main.xml
@@ -4176,6 +4176,66 @@
 		</p>
 	</song>
 
+	<song name="Satansvisan"
+		  author="J. Strauss, Strauss ex Machina"
+		  category="Esoterica"
+		  melody="Staffan var en stalledräng">
+		<p>
+			Algot är en ockultist
+			På onda böcker samla
+			En esoterisk nihilist
+			Som offra till Dom Gamla
+			Ingen Dagon synes än
+			Stjärnorna står fel, min vän, på himlen
+		</p>
+		<p>
+			Rosor är röda, violer blå
+			Klös och slå, hej och hå
+			Zombies är döda men traskar ändå
+			Hasar på rutten tå
+			Hjärnorna de smakar så härligt
+			Likstelheten knakar helt förfärligt
+			Köttet rått och skinnet grått
+			De fälls av ett huvudskott
+		</p>
+		<p>
+			En elak man från Helsingfors 
+			Han åkallade Satan
+			Med blåvitt inverterat kors
+			Men han var för lat, han 
+			Stackars lille djävulspräst
+			Finska Necronomicon är svårläst
+		</p>
+		<p>
+			Elof var en excorcist
+			Ifall att du blir besatt
+			Krucifix mot Antikrist
+			Onda skratt i julenatt
+			En gång var den besatte för galen
+			Elof läste fel i ritualen
+			Plötsligt hördes det ett dån
+			Han svaldes av en demon 
+		</p>
+		<p>
+			Birger är en lykantrop
+			Han ylar som en fåne
+			Vresigt pälsklädd, snar till dråp
+			Allt för den fulla måne
+			Dräpes lätt med silverspett
+			Akta dig för varulvsbett, din jävel
+		</p>
+		<p>
+			Gillar du att äta lik?
+			Ond bråd död, ditt levebröd
+			Då är varje kyrkogård ett fik
+			Ingen tid för griftefrid
+			Offerbål i natten vi tända
+			Kom och låt oss gravarna skända
+			Varje jul i detta land
+			En kyrka blir satt i brand
+		</p>
+	</song>
+
 	<song name="Sång till Stor-MUX"
 		  author="Erik Lundberg och Wilhelm Svenselius"
 		  category="Esoterica"
@@ -4645,6 +4705,7 @@
 			kommer aldrig mer igen. Tjo!
 		</p>
 	</song>
+<<<<<<< HEAD
 
 	<song name="Satanvisan"
 		  author="J. Strauss, Strauss ex Machina"
@@ -4669,6 +4730,8 @@
 			En kyrka blir satt i brand
 		</p>
 	</song>
+=======
+>>>>>>> amended satansvisan to have correct name, a listed author, and to contain the full song with all its verses. Also placed it in the right category, ordered it within said category, and fixed issues with character encoding of swedish letters.
 	
 	<song name="invITensången"
 		  author="Daniel Byström"


### PR DESCRIPTION
Såg att det blev lite underligt när Satansvisan skulle in, jag tror att det här löser alla problem, annars blir det --amend-tävling igen!

This pull request adds, amends or resolves the following:

- [x] Corrects the name of the song to "Satansvisan" from "Satanvisan"
- [x] Adds the authors listed in the source [youtube video](https://www.youtube.com/watch?v=14XUhHq6tqc)
- [x] Adds all verses of the song to allow the toastmaster to choose which parts to sing
- [x] Corrects the spelling of the category
- [x] Places the song in the (hopefully) correct position within ```main.xml```
- [x] Fixes some (possibly local) issues with encoding of the swedish characters ```åäö```