### PR TITLE
Remove "Ode till Treo" in favor of "Treo-Comp"

### DIFF
--- a/sangbok/main.xml
+++ b/sangbok/main.xml
@@ -1170,23 +1170,6 @@
 		</p>
 	</song>
 
-	<song name="Ode till Treo"
-		  category="Gasque"
-		  melody="Längtan till landet">
-		<p>
-			Morgonstund med smak av döda bävrar,
-			frukostmorgonen är över oss.
-			Hur vi stretar, hur vi alla vägrar,
-			så går solen likt förbannat opp.
-		</p>
-		<p>
-			Snart är dagen här med hemska plågor,
-			huvudvärk och ångest, elände, men
-			det finns faktiskt ett glas som dig kan rädda:
-			Treo-comp, vår frälsare och vän.
-		</p>
-	</song>
-
 	<song name="Anti-snapsvisa"
 		  category="Brännvin"
 		  melody="Sjösala vals">
@@ -1254,6 +1237,7 @@
 	</song>
 
 	<song name="Treo-comp"
+		  author="Lundakarnevalen, 1986"
 		  category="Gasque"
 		  melody="Längtan till landet">
 		<p>
@@ -1265,7 +1249,7 @@
 		<p>
 			Snart är dagen här med hemska plågor
 			huvudvärk och ångest, elände men
-			det finns faktiskt ett glas som dig kan hjälpa:
+			det finns faktiskt ett glas som dig kan rädda:
 			Treo-comp, vår frälsare och vän!
 		</p>
 	</song>


### PR DESCRIPTION
As mentioned in #18, this removed the duplication and fixes #18.

Remove "Ode till Treo" in favor of the more common namn "Treo-Comp".
Change "hjälpa" to "rädda" in the "Treo-Comp" Lyrics.
Add athour/origin of the song.
One of the sources from [D-sektionen Lund](https://www.dsek.se/arkiv/sanger/index.php?song=797).
